### PR TITLE
Changed method for checking field existence in object

### DIFF
--- a/lib/filter.js
+++ b/lib/filter.js
@@ -5,9 +5,9 @@ module.exports = function (input, fields, embeds) {
   ,   _embeds;
 
   fields.forEach(function (field) {
-    if (input[field.key]) {
+    if (field.key in input) {
       output[field.key] = input[field.key];
-    } else if (field.alias && input[field.alias]) {
+    } else if (field.alias && field.alias in input) {
       output[field.key] = input[field.alias];
     }
   });
@@ -17,7 +17,7 @@ module.exports = function (input, fields, embeds) {
     if (embed.alias) {
       field = embed.alias;
     } else { field = embed.key }
-    if (input[embed.key] || input[embed.alias]) {
+    if (embed.key in input || embed.alias in input) {
       output[embed.key] = _.map(input[field], function (item) {
         var __ = {};
         embed.fields.forEach(function (eField) {


### PR DESCRIPTION
The current method would leave out fields that were empty. In my case I had a field called description and if it were empty, it would not be part of the output.
